### PR TITLE
Make getSuperHeroByName not optional

### DIFF
--- a/KataSuperHeroes/GetSuperHeroByName.swift
+++ b/KataSuperHeroes/GetSuperHeroByName.swift
@@ -16,7 +16,7 @@ class GetSuperHeroByName {
         self.repository = repository
     }
 
-    func execute(_ superHeroName: String, completion: @escaping (SuperHero?) -> () ) {
+    func execute(_ superHeroName: String, completion: @escaping (SuperHero) -> () ) {
         repository.getSuperHero(withName: superHeroName) { superHero in
             completion(superHero)
         }

--- a/KataSuperHeroes/SuperHeroesRepository.swift
+++ b/KataSuperHeroes/SuperHeroesRepository.swift
@@ -109,10 +109,13 @@ class SuperHeroesRepository {
         }
     }
 
-    func getSuperHero(withName name: String, completion: @escaping (SuperHero?) -> ()) {
+    func getSuperHero(withName name: String, completion: @escaping (SuperHero) -> ()) {
         delay(1.5) {
-            let superHeroByName = self.superHeroes.filter { $0.name == name }.first
-            completion(superHeroByName)
+            if let superHeroByName = self.superHeroes.filter({ (superHero) -> Bool in
+                superHero.name == name
+                }).first {
+                completion(superHeroByName)
+            }
         }
     }
 

--- a/KataSuperHeroesTests/MockSuperHeroesRepository.swift
+++ b/KataSuperHeroesTests/MockSuperHeroesRepository.swift
@@ -17,8 +17,8 @@ class MockSuperHeroesRepository: SuperHeroesRepository {
         completion(superHeroes)
     }
 
-    override func getSuperHero(withName name: String, completion: @escaping (SuperHero?) -> ()) {
-        let superHeroByName = superHeroes.filter { $0.name == name }.first
+    override func getSuperHero(withName name: String, completion: @escaping (SuperHero) -> ()) {
+        let superHeroByName = superHeroes.filter { $0.name == name }.first!
         completion(superHeroByName)
     }
 


### PR DESCRIPTION
Closes #15 in order to get the same implementation for Android and iOS.